### PR TITLE
Adjust transition css style not to be so greedy

### DIFF
--- a/scrollReveal.js
+++ b/scrollReveal.js
@@ -292,8 +292,8 @@ window.scrollReveal = (function (window) {
           delay  = parsed.after   || this.options.after,
           easing = parsed.easing  || this.options.easing;
 
-      var transition = "-webkit-transition: all " + dur + " " + easing + " " + delay + ";" +
-                               "transition: all " + dur + " " + easing + " " + delay + ";" +
+      var transition = "-webkit-transition: -webkit-transform " + dur + " " + easing + " " + delay + ",  opacity " + dur + " " + easing + " " + delay + ";" +
+                               "transition: transform " + dur + " " + easing + " " + delay + ", opacity " + dur + " " + easing + " " + delay + ";" +
                       "-webkit-perspective: 1000;" +
               "-webkit-backface-visibility: hidden;";
 


### PR DESCRIPTION
Changed the transition css style property from the all value to two separate values, one for the transform and one for the opacity. Whilst developing on another project that uses scrollReveal (big fan by the way) I noticed that other css style properties that we set dynamically were also being transitioned.
