### PR TITLE
Refactor Style Caching

### DIFF
--- a/scrollReveal.js
+++ b/scrollReveal.js
@@ -27,12 +27,15 @@
 window.scrollReveal = (function (window) {
 
   'use strict';
+  
+  // generator (increments) for the next scroll-reveal-id
+  var nextId = 1;
 
   function scrollReveal(options) {
 
       this.docElem = window.document.documentElement;
       this.options = this.extend(this.defaults, options);
-      this.styleBank = [];
+      this.styleBank = {};
 
       if (this.options.init == true) this.init();
   }
@@ -72,8 +75,13 @@ window.scrollReveal = (function (window) {
       this.elems.forEach(function (el, i) {
 
     //  Capture original style attribute
-        if (!self.styleBank[el]) {
-          self.styleBank[el] = el.getAttribute('style');
+        var id = el.getAttribute("data-scroll-reveal-id");
+        if (!id) {
+            id = nextId++;
+            el.setAttribute("data-scroll-reveal-id", id);
+        }
+        if (!self.styleBank[id]) {
+          self.styleBank[id] = el.getAttribute('style');
         }
 
         self.update(el);
@@ -205,7 +213,7 @@ window.scrollReveal = (function (window) {
     update: function (el) {
 
       var css   = this.genCSS(el);
-      var style = this.styleBank[el];
+      var style = this.styleBank[el.getAttribute("data-scroll-reveal-id")];
 
       if (style != null) style += ";"; else style = "";
 


### PR DESCRIPTION
I noticed that to store the "start" style of a DOM element you are mapping the style to an array, styleBank. Couple of points, firstly, array is not the right type to use here as what you are doing is mapping so the correct type for styleBank is an object {}, use an array [] if you are going use push, splice, iteration, etc. Secondly, in some browsers when mapping a DOM element the browser will use the toString() function to generate the key, so what you get is the potential for map key conflicts.

What I have done instead is to generate a scroll-reveal-id attribute which will then generate an id for each DOM element. 

A side note of the styleBank map, it has the potential for memory leak if the integrating developer adds/removes a lot of DOM elements into the document, but that map clean-up should be handled in another issue if it is deemed a requirement.
