### PR TITLE
Execute self._scrollPage function.

### DIFF
--- a/scrollReveal.js
+++ b/scrollReveal.js
@@ -98,7 +98,7 @@ window.scrollReveal = (function (window) {
         if (!self.scrolled) {
           self.scrolled = true;
           requestAnimFrame(function () {
-            self._scrollPage
+            self._scrollPage();
           });
         }
       };


### PR DESCRIPTION
Fix to execute `self._scrollPage` function.

``` js
var scrollHandler = function (e) {
  // No changing, exit
  if (!self.scrolled) {
    self.scrolled = true;
    requestAnimFrame(function () {
      self._scrollPage();
    });
  }
};
```
