### PR TITLE
An approach to set viewFactor as a constant

### DIFF
--- a/src/scrollreveal.js
+++ b/src/scrollreveal.js
@@ -744,11 +744,41 @@
     return confirmBounds() || isPositionFixed()
 
     function confirmBounds () {
-      // Define the element’s functional boundaries using its view factor.
-      var top = elemTop + elemHeight * vF
-      var left = elemLeft + elemWidth * vF
-      var bottom = elemBottom - elemHeight * vF
-      var right = elemRight - elemWidth * vF
+      // Define the element’s functional boundaries using its view factor
+      var top, left, bottom, right
+	  
+	  // if viewFactor is defined as percentage
+      if ( vF > 0 && vF < 1 ) {
+	      
+	      top = elemTop + elemHeight * vF
+	      left = elemLeft + elemWidth * vF
+	      bottom = elemBottom - elemHeight * vF
+	      right = elemRight - elemWidth * vF
+	      
+      } else {
+	      
+	      if ( !(vF > elemHeight * 0.20) ) {
+		      // if viewFactor is not greater than the elements own 20% as set by defaults
+		      // then set the viewFactor boundary as a constant
+		      
+		      top = elemTop + vF
+		      left = elemLeft + vF
+		      bottom = elemBottom - vF
+		      right = elemRight - vF
+		  
+	      } else {
+		      // if viewFactor is greater than the elements
+			  // own 20% then fallback to defaults
+		      
+		      vF = ScrollReveal.prototype.defaults.viewFactor
+	      
+		      top = elemTop + elemHeight * vF
+		      left = elemLeft + elemWidth * vF
+		      bottom = elemBottom - elemHeight * vF
+		      right = elemRight - elemWidth * vF    		      
+
+	      }
+      }
 
       // Define the container functional boundaries using its view offset.
       var viewTop = scrolled.y + elem.config.viewOffset.top


### PR DESCRIPTION
The problem:

Im using scrollReveal to show full width section blocks as users scrolls down the page, sections which can sometimes be rather large in height. The percentage based viewFactor then would require a substantial amount of scroll before the animation is triggered leaving the viewport empty for a while.

An approach to the solution:

Extend the viewFactor option capabilities to be able to receive a number greater than 1.
If the vF is greater than 1 then set vF as a constant and not a percentage.
If the constant is greater than the own elements 20% then fall back to defaults.
