### PR TITLE
Add jsDelivr link

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@
 The simplest method is to copy paste this snippet just before your closing `</body>` tag.
 
 ```html
+<script src="https://cdn.jsdelivr.net/npm/scrollreveal/dist/scrollreveal.min.js"></script>
+<!-- or -->
 <script src="https://unpkg.com/scrollreveal/dist/scrollreveal.min.js"></script>
 ```
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/scrollreveal) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability. We also have detailed usage stats for project maintainers.