### PR TITLE
Fix for clean() function

### DIFF
--- a/src/instance/methods/clean.js
+++ b/src/instance/methods/clean.js
@@ -9,7 +9,7 @@ export default function clean (target) {
 			const id = node.getAttribute('data-sr-id')
 			if (id !== null) {
 				dirty = true
-				node.setAttribute('style', this.store.elements[id].styles.inline)
+				node.setAttribute('style', this.store.elements[id].styles.inline.generated)
 				node.removeAttribute('data-sr-id')
 				delete this.store.elements[id]
 			}


### PR DESCRIPTION
Was adding [object Object] for inline styles after reveal, which would be a problem if any inline styles was added before initialisation. See here https://codepen.io/ryanturner10/pen/pWQKbx