### PR TITLE
Allow array as first argument (for better compatibility with jQuery)

### DIFF
--- a/src/scrollreveal.js
+++ b/src/scrollreveal.js
@@ -308,6 +308,8 @@
       return [target]
     } else if (sr.tools.isNodeList(target)) {
       return Array.prototype.slice.call(target)
+    } else if (Array.isArray(target)) {
+      return target.filter(sr.tools.isNode)
     }
     return []
   }


### PR DESCRIPTION
It would be nice if I could supply an array of elements directly to the `reveal()` function. If you consider the following code using a jQuery object:

```js
window.sr = ScrollReveal({ reset: true });
window.sr.reveal($('img').toArray(), { duration: 1000 }, 200);
```

It currently fails because it is not a Node, NodeList, or a string selector, but it's already an array which is what the Node, NodeList, or string selector gets converted to anyway inside of scrollreveal.