### PR TITLE
Fix "Cannot read property 'bounds' of undefined' error" (#437)

### DIFF
--- a/src/instance/functions/delegate.js
+++ b/src/instance/functions/delegate.js
@@ -35,7 +35,7 @@ export default function delegate(
 		 * evaluated (in the second loop below).
 		 */
 		each(elements, element => {
-			if (stale) {
+			if (stale || element.geometry === undefined) {
 				element.geometry = getGeometry.call(this, element)
 			}
 			element.visible = isElementVisible.call(this, element)


### PR DESCRIPTION
<!--

Thank you for creating a pull request. Before submitting, please note the following:

* If your pull request implements a new feature, please raise an issue to discuss it before sending code.
* This message body should clearly illustrate what problems it solves.
* If there are related issues, remember to reference them.
* Ideally, include a test that fails without this PR but passes with it. PRs will only be merged once they pass CI.

-->

This PR is referencing #437 and fixes the  `Cannot read property 'bounds' of undefined'` error (see @mikehohs [comment](https://github.com/jlmakes/scrollreveal/issues/437#issuecomment-585740179) in this issue). The solution was originally proposed by @jlmakes but the issue got closed after there was no response (I guess). 

The error occurres when jumping back and forth between pages very quickly in a Vuejs SPA.
