### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/instance/functions/style.js
+++ b/src/instance/functions/style.js
@@ -55,7 +55,7 @@ export default function style(element) {
 		 */
 		let distance = config.distance
 		if (config.origin === 'top' || config.origin === 'left') {
-			distance = /^-/.test(distance) ? distance.substr(1) : `-${distance}`
+			distance = /^-/.test(distance) ? distance.slice(1) : `-${distance}`
 		}
 
 		const [value, unit] = distance.match(/(^-?\d+\.?\d?)|(em$|px$|%$)/g)


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.